### PR TITLE
ProximityScape Plugin

### DIFF
--- a/plugins/proximity-scap
+++ b/plugins/proximity-scap
@@ -1,0 +1,2 @@
+repository=https://github.com/warnerblue/proximityscape.git
+commit=66d0e93c2ffd83f011dada7a596c0eaa15bdb06b


### PR DESCRIPTION
This plugin enables the ability to have proximity chat in OSRS. It works by sending data to a Discord bot (World Number & Region) which then moves your linked Discord account. If you have any questions or concerns feel free to add me on Discord: warnerBlue#1458